### PR TITLE
CI: use nixpkgs master for ghp-import

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -77,7 +77,9 @@ jobs:
         uses: ./
         with:
           expr: |
-            pkgs.python3.withPackages (ps: with ps; [ ghp-import ])
+            (builtins.getFlake("github:nixos/nixpkgs/58c179406231ee9d24a9b5646e10df145322ca8e"))
+              .legacyPackages."x86_64-linux"
+              .python3.withPackages (ps: with ps; [ ghp-import ])
 
       - name: Push badge
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Use `ghp-import` from https://github.com/NixOS/nixpkgs/commit/58c179406231ee9d24a9b5646e10df145322ca8e until it is available in `nixos-unstable`.