### PR TITLE
CI: Rebuild bundled action if `package-lock.json` changed

### DIFF
--- a/.github/steps/build_action.py
+++ b/.github/steps/build_action.py
@@ -32,7 +32,8 @@ def main():
 
     last_commit: git.Commit = repo.commit(commits[-1]["id"])
     for diff in last_commit.diff(commits[0]["id"] + "~"):
-        if (diff.a_path or diff.b_path).startswith("src/"):
+        path = diff.a_path or diff.b_path
+        if path.startswith("src/") or path == "package-lock.json":
             break
     else:
         print("Source wasn't changed, nothing to do")


### PR DESCRIPTION
Currently, only changes to files in `src` trigger a rebuild, but changed dependencies should also rebuild the bundled action.