### PR TITLE
Prefer `RUNNER_TEMP` for temporary directory

### DIFF
--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -95,7 +95,7 @@ function createOrGetStateDir() {
         let tmpDir = process.env.STATE_NIX_PROFILE_TMPDIR;
         // Allow to execute this action multiple times with different packages
         if (!tmpDir) {
-            tmpDir = yield fs_1.promises.mkdtemp(path.join((0, os_1.tmpdir)(), "nix-profile-"));
+            tmpDir = yield fs_1.promises.mkdtemp(path.join(process.env.RUNNER_TEMP || (0, os_1.tmpdir)(), "nix-profile-"));
         }
         return tmpDir;
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,7 +65,9 @@ async function createOrGetStateDir(): Promise<string> {
   let tmpDir = process.env.STATE_NIX_PROFILE_TMPDIR;
   // Allow to execute this action multiple times with different packages
   if (!tmpDir) {
-    tmpDir = await promises.mkdtemp(path.join(tmpdir(), "nix-profile-"));
+    tmpDir = await promises.mkdtemp(
+      path.join(process.env.RUNNER_TEMP || tmpdir(), "nix-profile-"),
+    );
   }
 
   return tmpDir;


### PR DESCRIPTION
The directory which the `RUNNER_TEMP` env var points to is cleaned after each job run and it's also the place where the runner/other actions put their temporary files. Additionally, for sandboxed runners, the temporary directoy (as returned by `tmpdir`) is likely not accessible by the host's Nix, so the garbage collector thinks the profiles in this directory are no longer alive and garbage-collects them.