### PR TITLE
Use `path:` URLs instead of `file://` URLs

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -91,7 +91,7 @@ test("installs expr into profile without inputs-from", async () => {
 
   jest.spyOn(nix, "getRepoLockedUrl").mockImplementation(async (_path) => {
     expect(_path).toBe(path.resolve(process.cwd()));
-    return "file:///nix/store/nyr21fwgx0wzf1j94hd42icc7ffvh8jr-source?narHash=sha256-I4cKCEg3yeO0G4wuA/ohOJPdM2ag1FtqnhwEdsC8PDk=";
+    return "path:/nix/store/nyr21fwgx0wzf1j94hd42icc7ffvh8jr-source?narHash=sha256-I4cKCEg3yeO0G4wuA/ohOJPdM2ag1FtqnhwEdsC8PDk=";
   });
 
   jest
@@ -112,7 +112,7 @@ test("installs expr into profile without inputs-from", async () => {
       nixProfileDir,
       "--expr",
       `let
-         repoFlake = builtins.getFlake("file:///nix/store/nyr21fwgx0wzf1j94hd42icc7ffvh8jr-source?narHash=sha256-I4cKCEg3yeO0G4wuA/ohOJPdM2ag1FtqnhwEdsC8PDk=");
+         repoFlake = builtins.getFlake("path:/nix/store/nyr21fwgx0wzf1j94hd42icc7ffvh8jr-source?narHash=sha256-I4cKCEg3yeO0G4wuA/ohOJPdM2ag1FtqnhwEdsC8PDk=");
          inputsFromFlake = builtins.getFlake("");
          nixpkgs = builtins.getFlake("git+https://yaxi.tech?narHash=sha256-abcdef");
          pkgs = (import nixpkgs { system = "i686-linux"; });
@@ -150,7 +150,7 @@ test("installs packages and expr into profile with inputs-from", async () => {
   jest.spyOn(nix, "getFlakeLockedUrl").mockImplementation(async (flakeRef) => {
     switch (flakeRef) {
       case ".":
-        return "file:///nix/store/nyr21fwgx0wzf1j94hd42icc7ffvh8jr-source?narHash=sha256-I4cKCEg3yeO0G4wuA/ohOJPdM2ag1FtqnhwEdsC8PDk=";
+        return "path:/nix/store/nyr21fwgx0wzf1j94hd42icc7ffvh8jr-source?narHash=sha256-I4cKCEg3yeO0G4wuA/ohOJPdM2ag1FtqnhwEdsC8PDk=";
       default:
         throw Error(`Should not reach here: ${flakeRef}`);
     }
@@ -158,19 +158,19 @@ test("installs packages and expr into profile with inputs-from", async () => {
 
   jest.spyOn(nix, "getRepoLockedUrl").mockImplementation(async (_path) => {
     expect(_path).toBe(path.resolve(process.cwd()));
-    return "file:///nix/store/nyr21fwgx0wzf1j94hd42icc7ffvh8jr-source?narHash=sha256-I4cKCEg3yeO0G4wuA/ohOJPdM2ag1FtqnhwEdsC8PDk=";
+    return "path:/nix/store/nyr21fwgx0wzf1j94hd42icc7ffvh8jr-source?narHash=sha256-I4cKCEg3yeO0G4wuA/ohOJPdM2ag1FtqnhwEdsC8PDk=";
   });
 
   jest.spyOn(nix, "getRepoLockedUrl").mockImplementation(async (_path) => {
     expect(_path).toBe(path.resolve(process.cwd()));
-    return "file:///nix/store/nyr21fwgx0wzf1j94hd42icc7ffvh8jr-source?narHash=sha256-I4cKCEg3yeO0G4wuA/ohOJPdM2ag1FtqnhwEdsC8PDk=";
+    return "path:/nix/store/nyr21fwgx0wzf1j94hd42icc7ffvh8jr-source?narHash=sha256-I4cKCEg3yeO0G4wuA/ohOJPdM2ag1FtqnhwEdsC8PDk=";
   });
 
   jest.spyOn(nix, "getNixpkgs").mockImplementation(async (_path) => {
     expect(_path).toBe(
-      "file:///nix/store/nyr21fwgx0wzf1j94hd42icc7ffvh8jr-source?narHash=sha256-I4cKCEg3yeO0G4wuA/ohOJPdM2ag1FtqnhwEdsC8PDk=",
+      "path:/nix/store/nyr21fwgx0wzf1j94hd42icc7ffvh8jr-source?narHash=sha256-I4cKCEg3yeO0G4wuA/ohOJPdM2ag1FtqnhwEdsC8PDk=",
     );
-    return `(builtins.getFlake("file:///nix/store/q3ihs6gz300xg08jhvih2w7r50w7nbnn-source?narHash=sha256-KD9fHTbTnbbyG15Bprf43FwrShKfpkFk+p+hSp5wYoU=")).inputs.nixpkgs`;
+    return `(builtins.getFlake("path:/nix/store/q3ihs6gz300xg08jhvih2w7r50w7nbnn-source?narHash=sha256-KD9fHTbTnbbyG15Bprf43FwrShKfpkFk+p+hSp5wYoU=")).inputs.nixpkgs`;
   });
 
   jest
@@ -187,7 +187,7 @@ test("installs packages and expr into profile with inputs-from", async () => {
       "--profile",
       nixProfileDir,
       "--inputs-from",
-      "file:///nix/store/nyr21fwgx0wzf1j94hd42icc7ffvh8jr-source?narHash=sha256-I4cKCEg3yeO0G4wuA/ohOJPdM2ag1FtqnhwEdsC8PDk=",
+      "path:/nix/store/nyr21fwgx0wzf1j94hd42icc7ffvh8jr-source?narHash=sha256-I4cKCEg3yeO0G4wuA/ohOJPdM2ag1FtqnhwEdsC8PDk=",
       "nixpkgs#wuffmiau",
     ],
     { silent: false },
@@ -206,9 +206,9 @@ test("installs packages and expr into profile with inputs-from", async () => {
       nixProfileDir,
       "--expr",
       `let
-         repoFlake = builtins.getFlake("file:///nix/store/nyr21fwgx0wzf1j94hd42icc7ffvh8jr-source?narHash=sha256-I4cKCEg3yeO0G4wuA/ohOJPdM2ag1FtqnhwEdsC8PDk=");
-         inputsFromFlake = builtins.getFlake("file:///nix/store/nyr21fwgx0wzf1j94hd42icc7ffvh8jr-source?narHash=sha256-I4cKCEg3yeO0G4wuA/ohOJPdM2ag1FtqnhwEdsC8PDk=");
-         nixpkgs = (builtins.getFlake("file:///nix/store/q3ihs6gz300xg08jhvih2w7r50w7nbnn-source?narHash=sha256-KD9fHTbTnbbyG15Bprf43FwrShKfpkFk+p+hSp5wYoU=")).inputs.nixpkgs;
+         repoFlake = builtins.getFlake("path:/nix/store/nyr21fwgx0wzf1j94hd42icc7ffvh8jr-source?narHash=sha256-I4cKCEg3yeO0G4wuA/ohOJPdM2ag1FtqnhwEdsC8PDk=");
+         inputsFromFlake = builtins.getFlake("path:/nix/store/nyr21fwgx0wzf1j94hd42icc7ffvh8jr-source?narHash=sha256-I4cKCEg3yeO0G4wuA/ohOJPdM2ag1FtqnhwEdsC8PDk=");
+         nixpkgs = (builtins.getFlake("path:/nix/store/q3ihs6gz300xg08jhvih2w7r50w7nbnn-source?narHash=sha256-KD9fHTbTnbbyG15Bprf43FwrShKfpkFk+p+hSp5wYoU=")).inputs.nixpkgs;
          pkgs = (import nixpkgs { system = "i686-linux"; });
        in pkgs.wurzelpfropf`,
     ],

--- a/__tests__/nix.test.ts
+++ b/__tests__/nix.test.ts
@@ -53,7 +53,7 @@ test("getRepoLockedUrl works", async () => {
   jest.spyOn(nix, "getRepoLockedUrl");
 
   const res = await nix.getRepoLockedUrl(".");
-  expect(res).toMatch(/^file:\/\/\/nix\/store\/.*?\?narHash\=.*$/);
+  expect(res).toMatch(/^path:\/nix\/store\/.*?\?narHash\=.*$/);
   expect(nix.getRepoLockedUrl).toHaveBeenCalledTimes(1);
 });
 
@@ -69,7 +69,7 @@ test("getFlakeLockedUrl works", async () => {
   jest.spyOn(nix, "getFlakeLockedUrl");
 
   const res = await nix.getFlakeLockedUrl(".");
-  expect(res).toMatch(/^file:\/\/\/nix\/store\/.*?\?narHash\=.*$/);
+  expect(res).toMatch(/^path:\/nix\/store\/.*?\?narHash\=.*$/);
   expect(nix.getFlakeLockedUrl).toHaveBeenCalledTimes(1);
 });
 
@@ -99,7 +99,7 @@ test("getNixpkgs without inputs-from works", async () => {
   expect(inputsFromLockedUrl).toBe("");
   const res = await nix.getNixpkgs(inputsFromLockedUrl);
   expect(res).toMatch(
-    /^builtins\.getFlake\(\"file:\/\/\/nix\/store\/.*?\?narHash\=.*\"\)$/,
+    /^builtins\.getFlake\(\"path:\/nix\/store\/.*?\?narHash\=.*\"\)$/,
   );
   const execRes = await nix.runNix(["eval", "--json", "--expr", res], {
     ignoreReturnCode: true,

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -233,7 +233,7 @@ function maybeAddNixpkgs(pkg) {
 }
 function buildLockedUrl(metadata) {
     return __awaiter(this, void 0, void 0, function* () {
-        const url = new URL(`file://${metadata.path}`);
+        const url = new URL(`path:${metadata.path}`);
         url.searchParams.append("narHash", metadata.locked.narHash);
         return url.toString();
     });

--- a/src/nix.ts
+++ b/src/nix.ts
@@ -39,7 +39,7 @@ export async function maybeAddNixpkgs(pkg: string): Promise<string> {
 }
 
 async function buildLockedUrl(metadata: any) {
-  const url = new URL(`file://${metadata.path}`);
+  const url = new URL(`path:${metadata.path}`);
   url.searchParams.append("narHash", metadata.locked.narHash);
   return url.toString();
 }


### PR DESCRIPTION
`builtins.getFlake` doesn't seem to work with `file://` in Nix 2.28.1